### PR TITLE
Fix CORS pre-flight request handler

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -152,7 +152,7 @@ func handleCORS(req *http.Request, w http.ResponseWriter, resource *Resource) (p
 			maStr := strconv.Itoa((*corsConf).MaxAge)
 			w.Header().Set("Access-Control-Max-Age", maStr)
 		}
-		w.WriteHeader(http.StatusOK)
+		
 		preflight = true
 	} else {
 		// normal request
@@ -164,6 +164,9 @@ func handleCORS(req *http.Request, w http.ResponseWriter, resource *Resource) (p
 	w.Header().Add("Vary", "Origin")
 	if (*corsConf).Credentials {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+	if(preflight){
+		w.WriteHeader(http.StatusOK)
 	}
 	return
 }


### PR DESCRIPTION
I don't know if you already caught this, but I've moved the call to the WriteHeader function to the end of the handleCors function so that it isn't called until after all of the Headers are added to the responseWriter Headers. This makes sure that these headers are added during a pre-flight Options request before the call to WriteHeader which writes the headers into the response.