### PR TITLE
Ignore content-type parameter during decoder match

### DIFF
--- a/context.go
+++ b/context.go
@@ -147,9 +147,16 @@ func (c *Context) Redirect(urlStr string, code int) {
 // 	fmt.Fprintf(c.Writer, "")
 // }
 
+
 func (c *Context) contentDecoder() (Decoder, error) {
 	ct := c.Request.Header.Get("Content-Type")
-	return c.encoderEngine.GetDecoder(c.Request.Body, ct)
+	ct = strings.Replace(ct, " ", "", -1)
+	decoder, err := c.encoderEngine.GetDecoder(c.Request.Body, ct)
+	if(err != nil){
+		// If the full Content-Type doesn't match try matching only up to the ;
+		decoder, err = c.encoderEngine.GetDecoder(c.Request.Body, strings.Split(ct, ";")[0])
+	}
+	return decoder, err
 }
 
 func (c *Context) acceptableMediaTypes() []string {
@@ -168,7 +175,9 @@ func (c *Context) acceptableMediaTypes() []string {
 	sort.Sort(mt)
 	r := []string{}
 	for _, t := range mt {
-		r = append(r, t.String())
+		if(!t.Empty()){
+			r = append(r, t.String())
+		}
 	}
 	return r
 }

--- a/context_test.go
+++ b/context_test.go
@@ -366,7 +366,7 @@ func TestBindingWithJsonBody(t *testing.T) {
 	}
 }
 
-func TestBindingWithJsonBodyAndNoContentTypeSet(t *testing.T) {
+func TestBindingWithJsonBodyAndContentTypeWithParameter(t *testing.T) {
 	want := "Mango-34"
 	json := `   {"id":34,"name":"Mango"}`
 	r, _ := http.NewRequest("POST", "someurl", bytes.NewBufferString(json))

--- a/mediatype.go
+++ b/mediatype.go
@@ -13,6 +13,10 @@ type mediaType struct {
 	q           float32
 }
 
+func (m mediaType) Empty() bool {
+	return len(m.mainType) == 0 || len(m.subType) == 0
+}
+
 func (m mediaType) String() string {
 	return m.mainType + "/" + m.subType + m.rangeParams
 }


### PR DESCRIPTION
As we discussed I changed the contentDecoder func so that if it can't match the contentType to a decoder, then it will strip off any additional parameters and just try and match against the base mediaType.

Whilst looking at this I also found that the http package also provides a DetectContentType function which can look at the first 512 bytes of a payload to try and decide what mediaType it is if the Content-Type header has not been set. I did consider adding this but decided against it since it doesn't look for application/json. It defaults to application/octet-stream which didn't seem all that useful.

I added unit tests and checked the coverage. I noticed that acceptableMediaTypes func did not have 100% coverage so I added tests with invalid media type in the accept header to check that it gracefully failed. In order to get the error handling to gracefully ignore invalid mediaType I added an Empty() func to mediaType so that empty mediaType entries could be skipped in the acceptableMediaTypes func.